### PR TITLE
Use key instead of clip play position for firing event

### DIFF
--- a/Assets/Easy Animation Event/Source/Editor/AnimationEventHandlerEditor.cs
+++ b/Assets/Easy Animation Event/Source/Editor/AnimationEventHandlerEditor.cs
@@ -187,6 +187,10 @@ namespace EasyAnimationEvent
             GUILayout.EndHorizontal();
 
             GUILayout.Space(10); // Add some more spacing
+            
+            script.initializeOnAwake = GUILayout.Toggle(script.initializeOnAwake, "Initialize On Awake");
+            
+            GUILayout.Space(5); // Add some more spacing
 
             if (animator != null && animator.runtimeAnimatorController != null)
             {

--- a/Assets/Easy Animation Event/Source/Editor/AnimationEventHandlerEditor.cs
+++ b/Assets/Easy Animation Event/Source/Editor/AnimationEventHandlerEditor.cs
@@ -188,7 +188,7 @@ namespace EasyAnimationEvent
 
             GUILayout.Space(10); // Add some more spacing
             
-            script.initializeOnAwake = GUILayout.Toggle(script.initializeOnAwake, "Initialize On Awake");
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("initializeOnAwake"), new GUIContent("Initialize on Awake"));
             
             GUILayout.Space(5); // Add some more spacing
 

--- a/Assets/Easy Animation Event/Source/Runtime/AnimationEventHandler.cs
+++ b/Assets/Easy Animation Event/Source/Runtime/AnimationEventHandler.cs
@@ -19,13 +19,10 @@ namespace EasyAnimationEvent
 
         private void Awake()
         {
+            animator = GetComponent<Animator>();
+            
             if(!initializeOnAwake) return;
             
-            animator = GetComponent<Animator>();
-        }
-
-        private void Start()
-        {
             AddEvents();
         }
 

--- a/Assets/Easy Animation Event/Source/Runtime/AnimationEventHandler.cs
+++ b/Assets/Easy Animation Event/Source/Runtime/AnimationEventHandler.cs
@@ -15,8 +15,12 @@ namespace EasyAnimationEvent
         /// List of AnimationEventData instances representing animation events to manage.
         public List<AnimationEventData> animationEvents = new List<AnimationEventData>();
 
+        public bool initializeOnAwake = true;
+
         private void Awake()
         {
+            if(!initializeOnAwake) return;
+            
             animator = GetComponent<Animator>();
         }
 

--- a/Assets/Easy Animation Event/Source/Runtime/AnimationEventUtils.cs
+++ b/Assets/Easy Animation Event/Source/Runtime/AnimationEventUtils.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace EasyAnimationEvent
+{
+    public class AnimationEventUtils
+    {
+        public static string ConstructKey(AnimationClip clip, float time) => $"{clip.name}_{time}";
+    }
+}

--- a/Assets/Easy Animation Event/Source/Runtime/AnimationEventUtils.cs.meta
+++ b/Assets/Easy Animation Event/Source/Runtime/AnimationEventUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ad0cee0b07e04847807e752471e5a0cf
+timeCreated: 1758549007

--- a/Assets/Easy Animation Event/Source/Runtime/EventReceiver.cs
+++ b/Assets/Easy Animation Event/Source/Runtime/EventReceiver.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace EasyAnimationEvent
@@ -16,7 +17,7 @@ namespace EasyAnimationEvent
     public class EventReceiver : MonoBehaviour
     {
         // Dictionary storing callbacks and their names for each timeline position.
-        private readonly Dictionary<float, List<(Action callback, string name)>> CallbacksPoll = new Dictionary<float, List<(Action callback, string name)>>();
+        private readonly Dictionary<string, List<(Action callback, string name)>> CallbacksPoll = new Dictionary<string, List<(Action callback, string name)>>();
 
         /// <summary>
         /// Registers a callback to be invoked at a specific timeline position.
@@ -24,7 +25,7 @@ namespace EasyAnimationEvent
         /// <param name="position">The timeline position at which the callback should be invoked.</param>
         /// <param name="callback">The callback to register.</param>
         /// <param name="name">The name of the callback.</param>
-        public void RegisterEvent(float position, Action callback, string name)
+        public void RegisterEvent(string key, Action callback, string name)
         {
             if (callback == null)
             {
@@ -37,13 +38,13 @@ namespace EasyAnimationEvent
                 Debug.LogWarning("Attempted to register a callback with a null or empty name.");
                 return;
             }
-
-            if (!CallbacksPoll.ContainsKey(position))
+            
+            if (!CallbacksPoll.ContainsKey(key))
             {
-                CallbacksPoll[position] = new List<(Action callback, string name)>();
+                CallbacksPoll[key] = new List<(Action callback, string name)>();
             }
 
-            CallbacksPoll[position].Add((callback, name));
+            CallbacksPoll[key].Add((callback, name));
         }
 
         /// <summary>
@@ -52,17 +53,17 @@ namespace EasyAnimationEvent
         /// <param name="position">The timeline position from which the callback should be unregistered.</param>
         /// <param name="name">The name of the callback to unregister.</param>
         /// <returns>True if it was the last callback for the position and the position was removed; otherwise, false.</returns>
-        public bool UnregisterEvent(float position, string name)
+        public bool UnregisterEvent(string key)
         {
-            if (string.IsNullOrEmpty(name))
+            if (string.IsNullOrEmpty(key))
             {
                 Debug.LogWarning("Attempted to unregister a callback with a null or empty name.");
                 return false;
             }
 
-            if (!CallbacksPoll.TryGetValue(position, out var callbacks))
+            if (!CallbacksPoll.TryGetValue(key, out var callbacks))
             {
-                Debug.LogWarning($"Attempted to unregister a callback not registered at position {position}.");
+                Debug.LogWarning($"Attempted to unregister a callback not registered at key {key}.");
                 return false;
             }
 
@@ -78,7 +79,7 @@ namespace EasyAnimationEvent
 
             if (callbacks.Count == 0)
             {
-                CallbacksPoll.Remove(position);
+                CallbacksPoll.Remove(key);
                 return true;
             }
 
@@ -89,11 +90,11 @@ namespace EasyAnimationEvent
         /// Invoked by Unity's animation system to trigger callbacks at a specific timeline position.
         /// </summary>
         /// <param name="position">The timeline position at which to trigger callbacks.</param>
-        private void OnEvent(float position)
+        private void OnEvent(string key)
         {
-            if (!CallbacksPoll.TryGetValue(position, out var callbacks))
+            if (!CallbacksPoll.TryGetValue(key, out var callbacks))
             {
-                Debug.LogWarning($"No callbacks registered for timeline position {position}.");
+                Debug.LogWarning($"No callbacks registered for timeline position {key}.");
                 return;
             }
 

--- a/Assets/Easy Animation Event/Source/Runtime/Extensions/AnimationClipExtensions.cs
+++ b/Assets/Easy Animation Event/Source/Runtime/Extensions/AnimationClipExtensions.cs
@@ -84,7 +84,7 @@ namespace EasyAnimationEvent
                 }
 
                 // Register the callback at the specified timeline position
-                eventReceiver.RegisterEvent(position, callback, methodName);
+                eventReceiver.RegisterEvent(AnimationEventUtils.ConstructKey(clip, position), callback, methodName);
 
                 // Add an AnimationEvent to the AnimationClip if it doesn't already exist
                 clip.AddEventIfNotExists(OnEvent, position, position);
@@ -98,7 +98,7 @@ namespace EasyAnimationEvent
                 }
 
                 // Unregister the callback from the EventReceiver
-                var lastEventForPositionRemoved = eventReceiver.UnregisterEvent(position, methodName);
+                var lastEventForPositionRemoved = eventReceiver.UnregisterEvent(AnimationEventUtils.ConstructKey(clip, position));
                 if (lastEventForPositionRemoved)
                 {
                     // Remove the AnimationEvent from the AnimationClip if it was the last event at that position
@@ -116,16 +116,18 @@ namespace EasyAnimationEvent
         /// <param name="time">The time in the animation clip timeline associated with the event.</param>
         private static void AddEventIfNotExists(this AnimationClip clip, string methodName, float floatParameter, float time)
         {
+            var key = AnimationEventUtils.ConstructKey(clip, floatParameter);
+            
             var clipAnimationEvents = clip.events;
             var animationEvent = Array.Find(clipAnimationEvents,
-                e => e.functionName == methodName && e.floatParameter == floatParameter && e.time == time);
+                e => e.functionName == methodName && e.stringParameter == key && e.time == time);
 
             if (animationEvent == null)
             {
                 // Create a new AnimationEvent and add it to the AnimationClip
                 animationEvent = new AnimationEvent();
                 animationEvent.functionName = methodName;
-                animationEvent.floatParameter = floatParameter;
+                animationEvent.stringParameter = key;
                 animationEvent.time = time;
                 clip.AddEvent(animationEvent);
             }


### PR DESCRIPTION
Using clip position causes double event firing if we have 2 events that have the same clip time trigger point. So I switched it to use key with clip name + clip time.

Added bool to toggle whatever we want to register events in Awake or not at all.